### PR TITLE
[WIP] Fix hydration warning

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -6,7 +6,7 @@ function fromStorage<T>(value: string | null) {
   return value !== null ? (JSON.parse(value) as T) : null;
 }
 
-function readItem<T>(storage: StorageObj, key: string) {
+export function readItem<T>(storage: StorageObj, key: string) {
   try {
     const storedValue = storage.getItem(key);
     return fromStorage<T>(storedValue);

--- a/src/reducer.ts
+++ b/src/reducer.ts
@@ -1,7 +1,7 @@
-import { useReducer, Reducer, Dispatch } from 'react';
+import { useReducer, useEffect, Reducer, Dispatch } from 'react';
 
 import {
-  useInitialState,
+  readItem,
   useStorageListener,
   useStorageWriter,
   StorageObj,
@@ -54,8 +54,14 @@ function useStorageReducer<S, A, I = S>(
 
   const [state, dispatch] = useReducer(
     addForceStateActionToReducer(reducer),
-    useInitialState(storage, key, defaultState)
+    defaultState
   );
+
+  useEffect(() => {
+    const storageValue = readItem<S>(storage, key);
+    if (storageValue)
+      dispatch({ type: FORCE_STATE_ACTION, payload: storageValue });
+  }, [storage, key]);
 
   useStorageListener(storage, key, defaultState, (newValue: S) => {
     dispatch({ type: FORCE_STATE_ACTION, payload: newValue });


### PR DESCRIPTION
Fixes #17 

The SSR hydration warning can be avoided by always initialising with the defaultState and then subsequently updating the state in a `useEffect`. 

There is quite a major downside to this though, as the initial render will happen with the defaultState with am immediate re-render, which isn't ideal.

I don't think this is the right solution, but wanted to submit this to get your thoughts on the matter.