### PR TITLE
Distribute src folder to npm to make sourcemaps be available 

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "files": [
     "dist",
+    "src",
     "dist/index.d.ts"
   ],
   "author": "Ramón Guijarro <hola@soyguijarro.com>",


### PR DESCRIPTION
If you don't distribute the src directory the sourcemaps generated by typescript cannot be used